### PR TITLE
Added in npm ignore to allow user to ignore files like in a gitignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
   },
   "dependencies": {
     "group-css-media-queries": "^1.4.1",
+    "ignore": "^4.0.2",
     "less": "^2.7.2",
     "less-plugin-autoprefix": "^1.5.1",
     "less-plugin-clean-css": "^1.5.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 'use strict';
 import * as vscode from 'vscode';
+import ignore from 'ignore';
 import CompileLessCommand = require("./compiles/less/CompileLessCommand");
 import CompileSassCommand = require("./compiles/sass/CompileSassCommand");
 import CompileTsCommand = require("./compiles/typescript/CompileTsCommand");
@@ -67,9 +68,11 @@ export function activate(context: vscode.ExtensionContext) {
     // automatically compile on save
     let didSaveEvent = vscode.workspace.onDidSaveTextDocument((doc: vscode.TextDocument) =>
     {
+        let compileOptions = Configuration.getGlobalOptions(doc.fileName);
+        let ig = ignore().add(compileOptions.ignore);
         if (doc.fileName.endsWith(LESS_EXT) || doc.fileName.endsWith(TS_EXT) || doc.fileName.endsWith(SASS_EXT) || doc.fileName.endsWith(SCSS_EXT))
         {
-            vscode.commands.executeCommand(COMPILE_COMMAND);
+            if(!ig.ignores(doc.fileName)) vscode.commands.executeCommand(COMPILE_COMMAND);
         }
     });
     


### PR DESCRIPTION
user can specify an ignore array under easycompile.compile config to ignore filenames matching anything in the array.

```
"easycompile.compile": {
    "ignore" : [
        "**/_*.scss"
    ]
}
```
the above ignores scss files that begin with "_"

This is useful if you dont want to compile sub modules in your sass because they fail due to missing variables that are only accessible from the main file. I know this can be done by setting a "main" option in the submodules header, but when working with a team, not everyone  will have this extension install/ not everyone will be using vscode.