### PR TITLE
The ignores function expects a relative path.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -147,7 +147,7 @@ export function activate(context: vscode.ExtensionContext) {
             let compileOptions = Configuration.getGlobalOptions(filePath);
             if(compileOptions.ignore){
                 const ig = ignore().add(compileOptions.ignore);
-                if(ig.ignores(filePath)) return;
+                if(ig.ignores(filePath.slice(1))) return;
             }
             if (filePath.endsWith(LESS_EXT) || filePath.endsWith(TS_EXT) || filePath.endsWith(SASS_EXT) || filePath.endsWith(SCSS_EXT))
             {


### PR DESCRIPTION
I don't know how to get the relative path of the file correctly, but a temporary solution would be to add .slice(1) to line 137 of src/extension.js
```javascript
if (ig.ignores(filePath.slice(1)))
```